### PR TITLE
Update RNSvg.m

### DIFF
--- a/Libraries/RNSvg.m
+++ b/Libraries/RNSvg.m
@@ -36,7 +36,10 @@
 }
 
 - (void)setForceUpdate:(float)throwaway {
-  [self renderImage];
+  // only re-render once initialized
+  if(_imageView) {
+    [self renderImage];
+  }
 }
 
 - (void)renderImage


### PR DESCRIPTION
When immediately loading an <Svg> with a forceUpdate attribute, it throws an exception "Error setting property 'forceUpdate' of RNSvg with tag #157: Exception thrown while attempting to set property 'forceUpdate' of 'RNSvg' with value '0': CALayer position contains NaN: [0 nan]" It seems its because it's trying to calling forceUpdate too early? Adding the above if clause fixed my issue.

Also, it doesn't happen when using the simulator, but happens on a physical device.