### PR TITLE
Do not rely on type.displayName

### DIFF
--- a/Svg.js
+++ b/Svg.js
@@ -36,7 +36,7 @@ var Svg = React.createClass({
   },
 
   serialize(el) {
-    return Svg[el.type.displayName + 'Serializer'](el);
+    return Svg['PathSerializer'](el);
   },
 
   stateFromChildren() {


### PR DESCRIPTION
This is a quick fix for the following error (before ES6 Pull Request): 
`displayName is undefined` .

I guess it's happened since react-native@0.8.0+


